### PR TITLE
remove unnecessary line

### DIFF
--- a/src/main/java/carpet/mixins/rule/explosionNoBlockDamage/ExplosionMixin.java
+++ b/src/main/java/carpet/mixins/rule/explosionNoBlockDamage/ExplosionMixin.java
@@ -14,8 +14,7 @@ public abstract class ExplosionMixin {
             method = "damageEntities",
             at = @At(
                     value = "INVOKE",
-                    target = "Lnet/minecraft/world/World;getBlockState(Lnet/minecraft/util/math/BlockPos;)Lnet/minecraft/block/state/BlockState;",
-                    remap = false
+                    target = "Lnet/minecraft/world/World;getBlockState(Lnet/minecraft/util/math/BlockPos;)Lnet/minecraft/block/state/BlockState;"
             )
     )
     private BlockState explosionNoDamage(BlockState original) {


### PR DESCRIPTION
Remapping the `explosionNoDamage` injection in `carpet.mixins.rule.explosionNoBlockDamage.ExplosionMixin` was for some reason set to false, causing clients and servers to crash when an explosion was triggered. This removes the `remap = false` line

This description is just a copy-paste of the commit comment, lol