### PR TITLE
add validation for accurate placement protocol property

### DIFF
--- a/src/main/java/carpet/utils/feature/AccuratePlacementProtocol.java
+++ b/src/main/java/carpet/utils/feature/AccuratePlacementProtocol.java
@@ -54,7 +54,7 @@ public class AccuratePlacementProtocol {
         Direction direction = Direction.byId(extra % 10);
         extra = extra / 10;
         Property<Direction> property = firstPropertyOfType(state, Direction.class);
-        if (property != null) {
+        if (property != null && property.values().contains(direction)) {
             state = state.set(property, direction);
         }
         Block block = state.getBlock();


### PR DESCRIPTION
Fixes crash when trying to set `hopper[facing=up]` with tweakeroo's accurate/flexible placement.



```text
---- Minecraft Crash Report ----
// Daisy, daisy...

Time: 3/13/26 6:13 PM
Description: Unexpected error

java.lang.IllegalArgumentException: Cannot set property C_3858757{name=facing, clazz=class net.minecraft.unmapped.C_3544601, values=[down, north, south, west, east]} to up on block minecraft:hopper, it is not an allowed value
	at net.minecraft.unmapped.C_9264598$C_3876783.m_7179755(C_9264598.java:184)
	at carpet.utils.feature.AccuratePlacementProtocol.decodeAccuratePlacementProtocol(AccuratePlacementProtocol.java:58)
	at net.minecraft.unmapped.C_1264786.wrapOperation$zbc000$carpet$getPlacementState(C_1264786.java:1528)
	at net.minecraft.unmapped.C_1264786.m_3000450(C_1264786.java:47)
	at net.minecraft.unmapped.C_2454309.m_8878857(C_2454309.java:180)
	at net.minecraft.unmapped.C_5956487.m_1601703(C_5956487.java:356)
	at tweakeroo.tweaks.PlacementTweaks.processRightClickBlockWrapper(PlacementTweaks.java:842)
	at tweakeroo.tweaks.PlacementTweaks.handleFlexibleBlockPlacement(PlacementTweaks.java:921)
	at tweakeroo.tweaks.PlacementTweaks.tryPlaceBlock(PlacementTweaks.java:617)
	at tweakeroo.tweaks.PlacementTweaks.onProcessRightClickBlock(PlacementTweaks.java:434)
	at net.minecraft.unmapped.C_8105098.redirect$zmn000$tweakeroo$onProcessRightClickBlock(C_8105098.java:3205)
	at net.minecraft.unmapped.C_8105098.m_1075084(C_8105098.java:1501)
	at net.minecraft.unmapped.C_8105098.m_1978414(C_8105098.java:2017)
	at net.minecraft.unmapped.C_8105098.m_0673769(C_8105098.java:1822)
	at net.minecraft.unmapped.C_8105098.m_8832598(C_8105098.java:1665)
	at net.minecraft.unmapped.C_8105098.m_1241363(C_8105098.java:1000)
	at net.minecraft.unmapped.C_8105098.m_7986397(C_8105098.java:419)
	at net.minecraft.client.main.Main.main(Main.java:123)
	at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:514)
	at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:72)
	at net.fabricmc.loader.impl.launch.knot.KnotClient.main(KnotClient.java:23)
	at org.prismlauncher.launcher.impl.StandardLauncher.launch(StandardLauncher.java:115)
	at org.prismlauncher.EntryPoint.listen(EntryPoint.java:129)
	at org.prismlauncher.EntryPoint.main(EntryPoint.java:70)


A detailed walkthrough of the error, its code path and all known details is as follows:
---------------------------------------------------------------------------------------

-- Head --
Thread: Client thread
Stacktrace:
	at net.minecraft.unmapped.C_9264598$C_3876783.m_7179755(C_9264598.java:184)
	at carpet.utils.feature.AccuratePlacementProtocol.decodeAccuratePlacementProtocol(AccuratePlacementProtocol.java:58)
	at net.minecraft.unmapped.C_1264786.wrapOperation$zbc000$carpet$getPlacementState(C_1264786.java:1528)
	at net.minecraft.unmapped.C_1264786.m_3000450(C_1264786.java:47)
	at net.minecraft.unmapped.C_2454309.m_8878857(C_2454309.java:180)
	at net.minecraft.unmapped.C_5956487.m_1601703(C_5956487.java:356)
	at tweakeroo.tweaks.PlacementTweaks.processRightClickBlockWrapper(PlacementTweaks.java:842)
	at tweakeroo.tweaks.PlacementTweaks.handleFlexibleBlockPlacement(PlacementTweaks.java:921)
	at tweakeroo.tweaks.PlacementTweaks.tryPlaceBlock(PlacementTweaks.java:617)
	at tweakeroo.tweaks.PlacementTweaks.onProcessRightClickBlock(PlacementTweaks.java:434)
	at net.minecraft.unmapped.C_8105098.redirect$zmn000$tweakeroo$onProcessRightClickBlock(C_8105098.java:3205)
	at net.minecraft.unmapped.C_8105098.m_1075084(C_8105098.java:1501)
	at net.minecraft.unmapped.C_8105098.m_1978414(C_8105098.java:2017)
	at net.minecraft.unmapped.C_8105098.m_0673769(C_8105098.java:1822)
```